### PR TITLE
Fix unit admin icon view

### DIFF
--- a/bootstrap_select/static/bootstrap_select/bootstrap_select.css
+++ b/bootstrap_select/static/bootstrap_select/bootstrap_select.css
@@ -5,3 +5,12 @@
 .form-row {
   overflow: visible;
 }
+
+.form-row.field-icon {
+  overflow: hidden;
+}
+
+.bootstrap-select .dropdown-menu {
+  height: 500px;
+  width: 500px;
+}

--- a/bootstrap_select/widgets.py
+++ b/bootstrap_select/widgets.py
@@ -19,9 +19,9 @@ class BootstrapSelect(Select):
         js = ['//cdnjs.cloudflare.com/ajax/libs/bootstrap-select/1.12.4/js/bootstrap-select.min.js', ]  # noqa
 
         if self.bootstrap_css:
-            css['all'] = ['//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css'] + css['all']  # noqa
+            css['all'] = ['//maxcdn.bootstrapcdn.com/bootstrap/5.1.3/css/bootstrap.min.css'] + css['all']  # noqa
         if self.bootstrap_js:
-            js = ['//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js'] + js
+            js = ['//maxcdn.bootstrapcdn.com/bootstrap/5.1.3/js/bootstrap.min.js'] + js
         if self.jquery_js:
             js = ['//ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js'] + js
 


### PR DESCRIPTION
Current production view (before the fix):

<img width="1331" alt="Screenshot 2024-03-13 at 6 34 55 PM" src="https://github.com/voxy/django-bootstrap-select/assets/100217192/9c1eca4a-6eea-4d55-a0ff-d848b0e444d7">

<img width="1331" alt="Screenshot 2024-03-13 at 6 35 05 PM" src="https://github.com/voxy/django-bootstrap-select/assets/100217192/910063d4-5b57-453a-b46f-b0c1168fbdfc">

Local view (with this fix):

<img width="1331" alt="Screenshot 2024-03-13 at 6 35 30 PM" src="https://github.com/voxy/django-bootstrap-select/assets/100217192/722f2742-c004-402a-99f0-87450f6d560b">

<img width="1331" alt="Screenshot 2024-03-13 at 6 35 41 PM" src="https://github.com/voxy/django-bootstrap-select/assets/100217192/1bc7a438-5b79-434f-83db-0996886a2439">
